### PR TITLE
removal of join tables feature cannot be implemented due to issue wit…

### DIFF
--- a/lib/has_belongs/remove.rb
+++ b/lib/has_belongs/remove.rb
@@ -62,54 +62,54 @@ module HasBelongs
     def remove_migrations(filepath = 'app/models/', file = "db/schema.rb")
       migrations = []
       migrations << generate_has_and_one_remove_migrations(filepath, file)
-      migrations << generate_habtm_remove_migrations(filepath, file)
+      # migrations << generate_habtm_remove_migrations(filepath, file)
       if migrations.flatten.empty?
         raise "All files still contain relationships"
       end
       migrations.flatten
     end
 
-    def find_join_tables(file = "db/schema.rb")
-      join_table_models = []
-      File.open(file) do |file|
-        count = -1
-        file.each_line do |line|
-          count += 1
-          if line.include?("id: false")
-            model_one_line = IO.readlines(file)[count+1]
-            model_two_line = IO.readlines(file)[count+2]
-            model_one = model_one_line.split("\"")[1].gsub(/(_id)/, "")
-            model_two = model_two_line.split("\"")[1].gsub(/(_id)/, "")
-            join_table_models << [model_one, model_two]
-          end
-        end
-      end
-      join_table_models
-    end
+    # def find_join_tables(file = "db/schema.rb")
+    #   join_table_models = []
+    #   File.open(file) do |file|
+    #     count = -1
+    #     file.each_line do |line|
+    #       count += 1
+    #       if line.include?("id: false")
+    #         model_one_line = IO.readlines(file)[count+1]
+    #         model_two_line = IO.readlines(file)[count+2]
+    #         model_one = model_one_line.split("\"")[1].gsub(/(_id)/, "")
+    #         model_two = model_two_line.split("\"")[1].gsub(/(_id)/, "")
+    #         join_table_models << [model_one, model_two]
+    #       end
+    #     end
+    #   end
+    #   join_table_models
+    # end
 
-    def generate_habtm_remove_migrations(filepath = 'app/models/', file = "db/schema.rb")
-      output = []
-      tables = find_join_tables(file)
-      tables.each do |table|
-        model_one = table[0]
-        model_two = table[1]
-        if habtm_check(model_one, model_two, filepath) && habtm_check(model_two, model_one, filepath)
-          output << "bin/rails g migration RemoveJoinTable #{model_one} #{model_two}"
-        end
-      end
-      output
-    end
+    # def generate_habtm_remove_migrations(filepath = 'app/models/', file = "db/schema.rb")
+    #   output = []
+    #   tables = find_join_tables(file)
+    #   tables.each do |table|
+    #     model_one = table[0]
+    #     model_two = table[1]
+    #     if habtm_check(model_one, model_two, filepath) && habtm_check(model_two, model_one, filepath)
+    #       output << "bin/rails g migration RemoveJoinTable #{model_one} #{model_two}"
+    #     end
+    #   end
+    #   output
+    # end
 
-    private
+    # private
 
-    def habtm_check(first, second, filepath)
-      path = filepath + first + '.rb'
-      if File.open(path).each_line.any? do |line|
-          return false if line.include?("has_and_belongs_to_many :#{second}")
-        end
-      end
-      return true
-    end
+    # def habtm_check(first, second, filepath)
+    #   path = filepath + first + '.rb'
+    #   if File.open(path).each_line.any? do |line|
+    #       return false if line.include?("has_and_belongs_to_many :#{second}")
+    #     end
+    #   end
+    #   return true
+    # end
 
   end
 end

--- a/spec/remove_associations_spec.rb
+++ b/spec/remove_associations_spec.rb
@@ -32,11 +32,11 @@ describe 'remove_assocations' do
     expect(remove.generate_has_and_one_remove_migrations('spec/test_models_with_and_without_associations/', "spec/db_test/schema.rb")).to eq(["bin/rails g migration RemoveAuthorRefFromBooks author:references"])
   end
 
-  it 'can find join table models' do
+  pending it 'can find join table models' do
     expect(remove.find_join_tables("spec/db_test/schema.rb")).to eq [["book", "page"]]
   end
 
-  it 'can generate remove commands for removing habtm association' do
+  pending it 'can generate remove commands for removing habtm association' do
     expect(remove.generate_habtm_remove_migrations("spec/test_models_remove_habtm/", "spec/db_test/schema.rb")).to eq ["bin/rails g migration RemoveJoinTable book page"]
   end
 


### PR DESCRIPTION
…h rails

Rails currently does not have a command that will generate a remove drop table migration file. Once we have found a work-around to this we can re-factor our code to make this feature work.